### PR TITLE
Pass the original body through to the annotations

### DIFF
--- a/server/models/event.js
+++ b/server/models/event.js
@@ -46,7 +46,7 @@ EventModel.prototype.headers = function (val) {
 }
 
 EventModel.prototype.body = function (val) {
-	return this.ingest._body[val];
+	return (val) ? this.ingest._body[val] : this.ingest._body;
 }
 
 EventModel.prototype.pluck = function (val) {

--- a/server/pipelines/v3.js
+++ b/server/pipelines/v3.js
@@ -67,7 +67,7 @@ Pipeline.prototype.process = (message) => {
 		// calculate the end time in nano-seconds
 		var end = process.hrtime(start);
 		
-		event.annotate('original', event.body());
+		event.annotate('ingest', event.body());
 		event.annotate('geo', geo);
 		event.annotate('cohort', cohort);
 		event.annotate('validation', isValid);

--- a/server/pipelines/v3.js
+++ b/server/pipelines/v3.js
@@ -58,7 +58,7 @@ Pipeline.prototype.process = (message) => {
 				console.log('error', err);
 				return undefined;
 			});
-		}))	
+		}));
 	})
 	.then(annotations => {
 		
@@ -67,6 +67,7 @@ Pipeline.prototype.process = (message) => {
 		// calculate the end time in nano-seconds
 		var end = process.hrtime(start);
 		
+		event.annotate('original', event.body());
 		event.annotate('geo', geo);
 		event.annotate('cohort', cohort);
 		event.annotate('validation', isValid);
@@ -87,14 +88,19 @@ Pipeline.prototype.process = (message) => {
 		return Promise.resolve(event);
 
 	})	
-	.then(event => {
+	.then(event => {		// this set of enrichments are dependent on the first set 
 
 		var transforms = [
 			Promise.resolve(event),
 			transform.myFtApi(event)
 		];
 
-		return Promise.all(transforms);
+		return Promise.all(transforms.map(function (p) {	// allow rejections in individual promises without failing  
+			return p.catch(function (err) {
+				console.log('error', err);
+				return undefined;
+			});
+		}));
 	})
 	.then(annotations => {
 		

--- a/tests/server/models/eventSpec.js
+++ b/tests/server/models/eventSpec.js
@@ -60,10 +60,16 @@ describe('Event', () => {
 
 	describe('body', () => {
 	
-		it('Get the ingest body via a convenience method', done => {
+		it('Get a value from the ingest body via a convenience method', done => {
 			var e = new EventModel(rawSqs);
 			expect(e.body('videoid')).to.equal(4283366118001);
 			expect(e.body('position').a).to.equal(315.374);
+			done();
+		});
+		
+		it('Get the entire ingest body via a convenience method', done => {
+			var e = new EventModel(rawSqs);
+			expect(e.body().videoid).to.equal(4283366118001);
 			done();
 		});
 		


### PR DESCRIPTION
Not sure if this is creating excess duplication?

It's essentially a connivence method over `event.ingest._body`