### PR TITLE
Monitor the size of the ingest queue

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ app.set('port', (process.env.PORT || 5000));
 app.set('view engine', 'jade');
 
 app.get('/', require('./controllers/flags')); 
+app.get('/__health', require('./controllers/health')); 
 
 app.listen(app.get('port'), function() {
   console.log('Node app is running on port', app.get('port'));

--- a/server/controllers/health.js
+++ b/server/controllers/health.js
@@ -1,0 +1,60 @@
+
+var AWS				= require('aws-sdk'); 
+
+AWS.config.update({
+	accessKeyId: process.env.accessKey, 
+	secretAccessKey: process.env.secretAccessKey, 
+	"region": "eu-west-1"
+});
+
+var cloudwatch = (metric, threshold) => {
+
+	return new Promise((resolve, reject) => {
+	
+		new AWS.CloudWatch().getMetricStatistics({
+			Statistics: [ "Sum" ],
+			Dimensions: [ {"Name":"QueueName","Value":"spoor-ingest-v2"} ],
+			MetricName: metric,
+			Period: 60,
+			EndTime: new Date().toISOString(),
+			Namespace: "AWS/SQS",
+			StartTime: new Date(new Date() - (60 * 60 * 1000)).toISOString()
+		}, (err, data) => {
+			
+			if (err) {
+				reject(err);
+			}
+			
+			var a = data.Datapoints
+				.sort((a, b) => {
+					return new Date(a.Timestamp) > new Date(b.Timestamp) ? -1 : 1;
+				})
+				.slice(0, 3)
+				.map(data => {
+					data.Threshold = threshold;
+					data.ThresholdCrossed = data.Sum > threshold;
+					return data;
+				})
+			
+			resolve({
+				status: a.some(datapoint => !datapoint.ThresholdCrossed),
+				data: a
+			})
+
+		});
+	});
+}
+
+module.exports = (req, res) => {
+	
+	res.set('Cache-Control', 'max-age=10');
+	
+	cloudwatch('ApproximateNumberOfMessagesVisible', parseInt(req.query.threshold) || 5000)
+		.then(metrics => {
+			res.status(metrics.status ? 200 : 500);
+			res.json(metrics);
+		})
+		.catch(error => {
+			res.json({ ok: 0 });
+		})
+}

--- a/server/utils/metrics/cloudwatch.js
+++ b/server/utils/metrics/cloudwatch.js
@@ -47,7 +47,6 @@ setInterval(function () {
 					.splice(0, 1)
 					.forEach(function (e) {
 						e.UnixTime = new Date(e.Timestamp).getTime()/1000;
-						console.log('*', e);
 						metrics.count('cloudwatch.' + metric, e.Sum);
 					})
 			}


### PR DESCRIPTION
Will serve a HTTP 500 error if the ingest queue grows to more than 5000 items for 15 consecutive minutes